### PR TITLE
Fix typo in datastoreentity.md

### DIFF
--- a/entity/methods/datastoreentity.md
+++ b/entity/methods/datastoreentity.md
@@ -2,7 +2,7 @@
 
 ## datastoreEntity\(\)
 
-In case you need at any moment to fetch the entity **data** from Goolge Datastore, this method will do just that right on the entity instance.
+In case you need at any moment to fetch the entity **data** from Google Datastore, this method will do just that right on the entity instance.
 
 ```js
 const User = require('user.model');


### PR DESCRIPTION
I found a typo in [datastoreEntity()](https://sebelga.gitbooks.io/gstore-node/content/entity/methods/datastoreentity.html) page.

<img width="1060" alt="screen shot 2018-04-05 at 12 02 43" src="https://user-images.githubusercontent.com/2690781/38360179-dc39035a-38c9-11e8-8bcf-e305844b7191.png">
